### PR TITLE
マイページ実装

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+  def show
+    user = User.find(params[:id])
+    @items = user.items.includes(:purchase).order('created_at DESC')
+    @nickname = user.nickname
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,34 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
       <% @items.each do |item| %>
-        <li class='list'>
-          <%= link_to item_path(item.id) do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" %>
-
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <% if item.purchase.present? %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
-            <% end %>
-            <%# //商品が売れていればsold outを表示しましょう %>
-
-          </div>
-          <div class='item-info'>
-            <h3 class='item-name'>
-              <%= item.name %>
-            </h3>
-            <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
-              <div class='star-btn'>
-                <%= image_tag "star.png", class:"star-icon" %>
-                <span class='star-count'>0</span>
-              </div>
-            </div>
-          </div>
-          <% end %>
-        </li>
+        <%= render partial: 'shared/items', locals: { item: item } %>
       <% end %>
       <% unless @items.present? %>
         <li class='list'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,7 +40,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td>
+          <td class="detail-value"><%=link_to @item.user.nickname, user_path(@item.user_id) %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,15 +15,14 @@
       <li><%= link_to 'ブランド', "#", class: "brand-list" %></li>
     </ul>
     <ul class='lists-right'>
-      <%# deviseを導入できたら、ログインの有無で表示が変わるように分岐しましょう%>
+      <%# ログインの有無で表記変更 %>
       <% if user_signed_in? %>
-        <li><%= link_to current_user.nickname,"#", class: "user-nickname" %></li>
+        <li><%= link_to current_user.nickname, user_path(current_user.id), class: "user-nickname" %></li>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "logout" %></li> 
       <% else %>
         <li><%= link_to 'ログイン',  new_user_session_path, class: "login" %></li>
         <li><%= link_to '新規登録', new_user_registration_path, class: "sign-up" %></li>
       <% end %>
-      <%# //deviseを導入できたら、ログインの有無で表示が変わるように分岐しましょう%>
     </ul>
   </div>
 </header>

--- a/app/views/shared/_items.html.erb
+++ b/app/views/shared/_items.html.erb
@@ -1,0 +1,26 @@
+<li class='list'>
+  <%= link_to item_path(item.id) do %>
+  <div class='item-img-content'>
+    <%= image_tag item.image, class: "item-img" %>
+
+    <%# 商品が売れていればsold outを表示 %>
+    <% if item.purchase.present? %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+    <% end %>
+  </div>
+  <div class='item-info'>
+    <h3 class='item-name'>
+      <%= item.name %>
+    </h3>
+    <div class='item-price'>
+      <span><%= item.price %>円<br>(税込み)</span>
+      <div class='star-btn'>
+        <%= image_tag "star.png", class:"star-icon" %>
+        <span class='star-count'>0</span>
+      </div>
+    </div>
+  </div>
+  <% end %>
+</li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,13 @@
+  <%= render "shared/header" %>
+
+  <%# 商品一覧 %>
+  <div class='item-contents'>
+    <h2 class='title'><%= @nickname %>さんの出品商品一覧</h2>
+    <ul class='item-lists'>
+      <% @items.each do |item| %>
+        <%= render partial: 'shared/items', locals:{ item: item } %>
+      <% end %>
+    </ul>
+  </div>
+  <%# /商品一覧 %>
+  <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
     resources :purchases, only: [:index, :create]
     resources :comments, only: [:create]
   end
+  resources :users, only: :show
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+
+end


### PR DESCRIPTION
# what
- マイページの実装
- ヘッターにあるログインユーザー名をクリックするとマイページに遷移する
- 商品詳細ページの出品者の名前をクリックするとそのユーザーの詳細ページに遷移、出品商品を一覧で確認できる

# why
- ユーザーの投稿商品の一覧を見れる様にするため

 ### 機能確認
- マイページへ遷移
https://gyazo.com/4560d4c7b5727c3f81049bd183da00e0
- 商品詳細ページから出品者のマイページへ遷移
https://gyazo.com/40749ed91e2cd41fbbffe93173014471